### PR TITLE
Fixing missing command on test action

### DIFF
--- a/gruntConfig.coffee
+++ b/gruntConfig.coffee
@@ -65,7 +65,7 @@ module.exports = (grunt, initConfig={}) ->
         command: 'npm install'
       
       test:
-        command: 'node_modules/bumble-test/bin/testRunner.coffee'
+        command: 'coffee node_modules/bumble-test/bin/testRunner.coffee'
 
 
     availabletasks:


### PR DESCRIPTION
Fixed missing command (coffee) in "test" because it was failing to run on windows.
